### PR TITLE
README: working example config for gitlab.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can install emacs-gitlab manually by placing it on your `load-path` and
 
 * Setup your Gitlab configurations :
 
-        $ (setq gitlab-host "http://mygitlab.com"
+        $ (setq gitlab-host "https://gitlab.com"
                 gitlab-username "foo"
                 gitlab-password "bar")
 


### PR DESCRIPTION
I suggest to make the example config work for some people, so for gitlab.com. In that case, it needs https. It could be tricky to catch…
